### PR TITLE
Formatting fix for GPUs that lack temp/fan data

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -1776,13 +1776,14 @@ static void curses_print_devstatus(int thr_id)
 	if (wmove(statuswin, ypos, 0) == ERR)
 		return;
 	wprintw(statuswin, " %s %*d: ", cgpu->api->name, dev_width, cgpu->device_id);
-	if (cgpu->api->get_statline_before) {
-		logline[0] = '\0';
-		cgpu->api->get_statline_before(logline, cgpu);
-		wprintw(statuswin, "%s", logline);
-	}
-	else
-		wprintw(statuswin, "               | ");
+
+	logline[0] = '\0';
+	if (cgpu->api->get_statline_before)
+	  cgpu->api->get_statline_before(logline, cgpu);
+	if (logline[0])
+	  wprintw(statuswin, "%s", logline);
+	else			/* no statline (cpu) or empty statline (nvidia) */
+	  wprintw(statuswin, "               | ");		
 
 	char cHr[h2bs_fmt_size[H2B_NOUNIT]], aHr[h2bs_fmt_size[H2B_NOUNIT]], uHr[h2bs_fmt_size[H2B_SHORT]];
 	ti_hashrate_bufstr(


### PR DESCRIPTION
My system has an NVidia card, for which get_statline_before returns an empty string, so the status looks like:

```
OCL  0:|  37.9/ 38.2/ 41.2Mh/s | A:14 R:0 HW:0 U: 0.58/m
CPU  0:                |   1.1/  1.2/  0.0Mh/s | A: 0 R:0 HW:0 U: 0.00/m
CPU  1:                |   1.2/  0.7/  0.0kh/s | A: 0 R:0 HW:0 U: 0.00/m
```

This commit prints the proper amount of whitespace in this situation by checking for an empty string.
