### PR TITLE
Fix for issue #167 / BFGMiner crash with access violation

### DIFF
--- a/ocl.c
+++ b/ocl.c
@@ -557,7 +557,7 @@ _clState *initCl(unsigned int gpu, char *name, size_t nameSize)
 	 */
 	char binaryfilename[255];
 	char filename[255];
-	char numbuf[10];
+	char numbuf[32];
 
 	if (cgpu->kernel == KL_NONE) {
 		if (opt_scrypt) {

--- a/ocl.c
+++ b/ocl.c
@@ -652,7 +652,6 @@ _clState *initCl(unsigned int gpu, char *name, size_t nameSize)
 #ifdef USE_SCRYPT
 	if (opt_scrypt) {
 		cl_ulong ma = cgpu->max_alloc, mt;
-		int pow2 = 0;
 
 		if (!cgpu->opt_lg) {
 			applog(LOG_DEBUG, "GPU %d: selecting lookup gap of 2", gpu);
@@ -676,12 +675,10 @@ _clState *initCl(unsigned int gpu, char *name, size_t nameSize)
 		 * >= required amount to map nicely to an intensity */
 		mt = cgpu->thread_concurrency * 32768 * cgpu->lookup_gap;
 		if (ma > mt) {
-			while (ma >>= 1)
-				pow2++;
 			ma = 1;
-			while (--pow2 && ma < mt)
+			while (ma < mt)
 				ma <<= 1;
-			if (ma >= mt) {
+			if (ma < cgpu->max_alloc) {
 				cgpu->max_alloc = ma;
 				applog(LOG_DEBUG, "Max alloc decreased to %lu", cgpu->max_alloc);
 			}


### PR DESCRIPTION
This is a fix for issue #167

First, the access violation was cause by line #721 from ocl.c where "numbuf" was to small for any thread-concurrency > 9999. To fix it I just increased the size of numbuf from 10 chars to 32.
Another possible way to fix it is to split the operation from lines #721-722 into 2 , first process lookup_gap then thread_concurrency.

After that I was able to use thread_concurrency up to 16384. For more memory allocation for padbuffer8 buffer failed. Failure is due to logic  that supposed to find the smallest power of 2 value >= required amount of memory. Old logic works fine only if board have memory size a power of 2. The new logic just find the smallest power of 2 value and if it is small enough (less than board memory size) it use it.
