### PR TITLE
Fix null pointer issue when one chip on an X6500 is not initialized yet ...

### DIFF
--- a/driver-x6500.c
+++ b/driver-x6500.c
@@ -466,6 +466,8 @@ void x6500_get_temperature(struct cgpu_info *x6500)
 		struct thr_info *thr = x6500->thr[i];
 		fpga = thr->cgpu_data;
 
+		if (!fpga) continue;
+
 		if (code[i] == 0xffff || !code[i]) {
 			fpga->temp = 0;
 			continue;


### PR DESCRIPTION
...when reading temperature.
