### PR TITLE
fix infinite loop in bytes_cpy when size is zero

### DIFF
--- a/util.h
+++ b/util.h
@@ -182,7 +182,7 @@ void bytes_cpy(bytes_t *dst, const bytes_t *src)
 	dst->allocsz = src->allocsz;
 	dst->sz = src->sz;
 	size_t half;
-	while (dst->sz <= (half = dst->allocsz / 2))
+	while (dst->allocsz > 0 && dst->sz <= (half = dst->allocsz / 2))
 		dst->allocsz = half;
 	dst->buf = malloc(dst->allocsz);
 	memcpy(dst->buf, src->buf, dst->sz);

--- a/util.h
+++ b/util.h
@@ -179,10 +179,15 @@ void bytes_cat(bytes_t *b, const bytes_t *cat)
 static inline
 void bytes_cpy(bytes_t *dst, const bytes_t *src)
 {
-	dst->allocsz = src->allocsz;
 	dst->sz = src->sz;
+	if (!dst->sz) {
+		dst->allocsz = 0;
+		dst->buf = NULL;
+		return;
+	}
+	dst->allocsz = src->allocsz;
 	size_t half;
-	while (dst->allocsz > 0 && dst->sz <= (half = dst->allocsz / 2))
+	while (dst->sz <= (half = dst->allocsz / 2))
 		dst->allocsz = half;
 	dst->buf = malloc(dst->allocsz);
 	memcpy(dst->buf, src->buf, dst->sz);


### PR DESCRIPTION
Beside this bug, I don't know if update_last_work() should call copy_work with zero-sized nonce2.
