### PR TITLE
Support for bitfurystrikesback boards

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -211,7 +211,7 @@ bfgminer_SOURCES += driver-ztex.c libztex.c libztex.h
 endif
 
 if HAS_BITFURY
-bfgminer_SOURCES += driver-bitfury.c libbitfury.c libbitfury.h spidevc.h spidevc.c driver-metabank.c tm_i2c.h tm_i2c.c
+bfgminer_SOURCES += driver-bitfury.c libbitfury.c libbitfury.h spidevc.h spidevc.c driver-metabank.c tm_i2c.h tm_i2c.c driver-bfsb.c
 
 if HAS_LITTLEFURY
 bfgminer_SOURCES += driver-littlefury.c

--- a/driver-bfsb.c
+++ b/driver-bfsb.c
@@ -71,6 +71,7 @@ struct bitfury_device **bfsb_detect_chips(int *out_count) {
 			*port = *sys_spi;
 			port->cgpu = &dummy_cgpu;
 			port->txrx = bfsb_spi_txrx;
+			port->speed = 625000;
 			dummy_bitfury.slot = i;
 			
 			chip_n = libbitfury_detectChips1(port);

--- a/driver-bfsb.c
+++ b/driver-bfsb.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2013 bitfury
+ * Copyright 2013 legkodymov
+ * Copyright 2013 Luke Dashjr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "deviceapi.h"
+#include "libbitfury.h"
+#include "spidevc.h"
+
+
+struct device_drv bfsb_drv;
+
+static
+bool bfsb_spi_txrx(struct spi_port *port)
+{
+	struct cgpu_info * const proc = port->cgpu;
+	struct bitfury_device * const bitfury = proc->device_data;
+	spi_bfsb_select_bank(bitfury->slot);
+	const bool rv = sys_spi_txrx(port);
+
+	return rv;
+}
+
+static
+struct bitfury_device **bfsb_detect_chips(int *out_count) {
+	struct bitfury_device **devicelist, *bitfury;
+	struct spi_port *port;
+	int n = 0;
+	int i, j;
+	bool slot_on[32];
+	struct timespec t1, t2;
+	struct bitfury_device dummy_bitfury;
+	struct cgpu_info dummy_cgpu;
+	int max_devices = 100;
+
+
+	devicelist = malloc(max_devices * sizeof(*devicelist));
+	dummy_cgpu.device_data = &dummy_bitfury;
+	
+	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t1);
+	for (i = 0; i < 4; i++) {
+		slot_on[i] = 1;
+	}
+
+	for (i = 0; i < 32; i++) {
+		if (slot_on[i]) {
+			int chip_n;
+			
+			port = malloc(sizeof(*port));
+			*port = *sys_spi;
+			port->cgpu = &dummy_cgpu;
+			port->txrx = bfsb_spi_txrx;
+			dummy_bitfury.slot = i;
+			
+			chip_n = libbitfury_detectChips1(port);
+			if (chip_n)
+			{
+				applog(LOG_WARNING, "BITFURY slot %d: %d chips detected", i, chip_n);
+				for (j = 0; j < chip_n; ++j)
+				{
+					if (unlikely(n >= max_devices))
+					{
+						max_devices *= 2;
+						devicelist = realloc(devicelist, max_devices * sizeof(*devicelist));
+					}
+					devicelist[n] = bitfury = malloc(sizeof(*bitfury));
+					*bitfury = (struct bitfury_device){
+						.spi = port,
+						.slot = i,
+						.fasync = j,
+					};
+					n++;
+				}
+			}
+			else
+				free(port);
+		}
+	}
+
+	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t2);
+
+	*out_count = n;
+	return devicelist;
+}
+
+static
+int bfsb_autodetect()
+{
+	RUNONCE(0);
+	
+	int chip_n;
+	struct cgpu_info *bitfury_info;
+
+	bitfury_info = calloc(1, sizeof(struct cgpu_info));
+	bitfury_info->drv = &bfsb_drv;
+	bitfury_info->threads = 1;
+
+	applog(LOG_INFO, "INFO: bitfury_detect");
+	spi_init();
+	if (!sys_spi)
+		return 0;
+	bitfury_info->device_data = bfsb_detect_chips(&chip_n);
+	if (!chip_n) {
+		applog(LOG_WARNING, "No Bitfury chips detected!");
+		return 0;
+	} else {
+		applog(LOG_WARNING, "BITFURY: %d chips detected!", chip_n);
+	}
+
+	bitfury_info->procs = chip_n;
+	add_cgpu(bitfury_info);
+	
+	return 1;
+}
+
+static void bfsb_detect(void)
+{
+	noserial_detect_manual(&bfsb_drv, bfsb_autodetect);
+}
+
+extern bool bitfury_prepare(struct thr_info *);
+
+static
+bool bfsb_init(struct thr_info *thr)
+{
+	struct bitfury_device **devicelist = thr->cgpu->device_data;
+	struct cgpu_info *proc;
+	struct bitfury_device *bitfury;
+	
+	for (proc = thr->cgpu; proc; proc = proc->next_proc)
+	{
+		bitfury = devicelist[proc->proc_id];
+		proc->device_data = bitfury;
+		bitfury->spi->cgpu = proc;
+	}
+	
+	free(devicelist);
+	
+	return true;
+}
+
+extern int64_t bitfury_scanHash(struct thr_info *);
+extern void bitfury_shutdown(struct thr_info *);
+
+static void bfsb_shutdown(struct thr_info *thr)
+{
+	bitfury_shutdown(thr);
+	spi_bfsb_select_bank(-1);
+}
+
+struct device_drv bfsb_drv = {
+	.dname = "bitfurystrikesback",
+	.name = "BSB",
+	.drv_detect = bfsb_detect,
+	
+	.minerloop = hash_queued_work,
+	.thread_prepare = bitfury_prepare,
+	.thread_init = bfsb_init,
+	.scanwork = bitfury_scanHash,
+	.thread_shutdown = bfsb_shutdown,
+};

--- a/miner.c
+++ b/miner.c
@@ -9390,6 +9390,7 @@ extern struct device_drv ztex_drv;
 #ifdef USE_BITFURY
 extern struct device_drv bitfury_drv;
 extern struct device_drv metabank_drv;
+extern struct device_drv bfsb_drv;
 #endif
 
 static int cgminer_id_count = 0;
@@ -9500,6 +9501,7 @@ void drv_detect_all()
 	{
 		bitfury_drv.drv_detect();
 		metabank_drv.drv_detect();
+		bfsb_drv.drv_detect();
 	}
 #endif
 

--- a/spidevc.h
+++ b/spidevc.h
@@ -20,6 +20,7 @@ struct spi_port {
 	struct cgpu_info *cgpu;
 	const char *repr;
 	int logprio;
+	int speed;
 };
 
 extern struct spi_port *sys_spi;
@@ -70,5 +71,7 @@ bool spi_txrx(struct spi_port *port)
 }
 
 extern bool sys_spi_txrx(struct spi_port *);
+
+void spi_bfsb_select_bank(int bank);
 
 #endif


### PR DESCRIPTION
This is a quick hack to make bfgminer to work on bitfurystrikesback boards.

Works mostly the same as metabank boards, but spi speed is lower due to longer chains of chips.

This driver actually should not be autodetected as it is incompatible with the megabigpower boards.
