### PR TITLE
Link libblkmaker statically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -620,21 +620,9 @@ if test "x$with_system_libblkmaker" = "xyes"; then
 		AC_MSG_ERROR([Could not find system libblkmaker])
 	])
 else
-	save_LDFLAGS="$LDFLAGS"
-	LDFLAGS="$LDFLAGS -Wl,-zorigin"
-	origin_LDFLAGS=
-	AC_MSG_CHECKING([whether the linker recognizes the -zorigin option])
-	AC_TRY_LINK([],[],[
-		AC_MSG_RESULT([yes])
-		origin_LDFLAGS=',-zorigin'
-	],[
-		AC_MSG_RESULT([no])
-	])
-	LDFLAGS="$save_LDFLAGS"
-	
 	libblkmaker_CFLAGS='-Ilibblkmaker'
-	libblkmaker_LDFLAGS='-Llibblkmaker/.libs -Wl,-rpath,\$$ORIGIN/libblkmaker/.libs'"$origin_LDFLAGS"
-	libblkmaker_LIBS='-lblkmaker_jansson-0.1 -lblkmaker-0.1'
+	libblkmaker_LDFLAGS=''
+	libblkmaker_LIBS='libblkmaker/.libs/libblkmaker_jansson-0.1.a libblkmaker/.libs/libblkmaker-0.1.a'
 	AC_CONFIG_SUBDIRS([libblkmaker])
 fi
 AC_SUBST(libblkmaker_CFLAGS)


### PR DESCRIPTION
Is there any specific reason for libblkmaker being linked dynamically and in specific path? If there is no such reason, I think it would be better to link it statically. 

In this case there is also a minor change in libblkmaker's configure.ac file:

``` patch
diff --git a/configure.ac b/configure.ac
index 8102143..6e7fc70 100644
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AM_INIT_AUTOMAKE([1.10 -Wall dist-bzip2])

 AC_PROG_CC_C99
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-LT_INIT([disable-static])
+LT_INIT()

 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 AC_SUBST([LIBBLKMAKER_SO_VERSION], [4:1:4])
```
