### PR TITLE
Use a lowercase driver name to fix --scan pattern matching

### DIFF
--- a/driver-twinfury.c
+++ b/driver-twinfury.c
@@ -533,7 +533,8 @@ void twinfury_wlogprint_status(struct cgpu_info * const proc)
 
 //------------------------------------------------------------------------------
 struct device_drv twinfury_drv = {
-	.dname = "Twinfury",
+        //lowercase driver name so --scan pattern matching works
+	.dname = "twinfury",
 	.name = "TBF",
 	.probe_priority = -111,
 


### PR DESCRIPTION
Otherwise the following doesn't work: -S noauto -S twinfury:auto
