### PR TITLE
Bugfix: don’t attempt to probe Bluetooth devices when scanning hardware

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -1179,7 +1179,9 @@ void _vcom_devinfo_scan_lsdev(struct lowlevel_device_info ** const devinfo_list)
 	memcpy(devpath, devdir, devdirlen);
 	devpath[devdirlen] = '/';
 	while ( (de = readdir(D)) ) {
-		if (!strncmp(de->d_name, "cu.", 3))
+		if (!strncmp(de->d_name, "cu.", 3)
+			//don't probe Bluetooth devices - causes bus errors and segfaults
+			&& strncmp(de->d_name, "cu.Bluetooth", 12))
 			goto trydev;
 		if (strncmp(de->d_name, "tty", 3))
 			continue;


### PR DESCRIPTION
Causes bus errors and segfaults on OS X
