### PR TITLE
Bugfix: HID API not properly detected on Mac OS X

### DIFF
--- a/lowl-hid.c
+++ b/lowl-hid.c
@@ -115,6 +115,10 @@ bool hidapi_load_library()
 		sprintf(&dlname[9], "%s.%s", *p,
 #ifdef WIN32
 		        "dll"
+#elif defined(__APPLE__)
+		        //Mach-O uses dylibs for shared libraries
+		        //http://www.finkproject.org/doc/porting/porting.en.html#shared
+		        "dylib"
 #else
 		        "so"
 #endif


### PR DESCRIPTION
Mach-O uses dylibs for shared libraries: http://www.finkproject.org/doc/porting/porting.en.html#shared
