### PR TITLE
Bugfix: Do not allocate spi_port on the Stack, even to initialize

### DIFF
--- a/driver-hashbuster.c
+++ b/driver-hashbuster.c
@@ -231,15 +231,16 @@ bool hashbuster_init(struct thr_info * const thr)
 	port = malloc(sizeof(*port));
 	if (!port)
 		applogr(false, LOG_ERR, "%s: Failed to allocate spi_port", cgpu->dev_repr);
-	*port = (struct spi_port){
-		.txrx = hashbuster_spi_txrx,
-		.userp = h,
-		.cgpu = cgpu,
-		.repr = cgpu->dev_repr,
-		.logprio = LOG_ERR,
-		.speed = 100000,
-		.mode = 0,
-	};
+	
+	/* Be careful, read spidevc.h comments for warnings */
+	memset(port, 0, sizeof(*port));
+	port->txrx = hashbuster_spi_txrx;
+	port->userp = h;
+	port->cgpu = cgpu;
+	port->repr = cgpu->dev_repr;
+	port->logprio = LOG_ERR;
+	port->speed = 100000;
+	port->mode = 0;
 	
 	for (proc = cgpu; proc; proc = proc->next_proc)
 	{

--- a/driver-knc.c
+++ b/driver-knc.c
@@ -317,16 +317,17 @@ nomorecores: ;
 		.cgpu = cgpu,
 		.workqueue_max = 1,
 	};
-	*spi = (struct spi_port){
-		.txrx = knc_spi_txrx,
-		.cgpu = cgpu,
-		.repr = knc_drv.dname,
-		.logprio = LOG_ERR,
-		.speed = KNC_SPI_SPEED,
-		.delay = KNC_SPI_DELAY,
-		.mode  = KNC_SPI_MODE,
-		.bits  = KNC_SPI_BITS,
-	};
+	
+	/* Be careful, read spidevc.h comments for warnings */
+	memset(spi, 0, sizeof(*spi));
+	spi->txrx = knc_spi_txrx;
+	spi->cgpu = cgpu;
+	spi->repr = knc_drv.dname;
+	spi->logprio = LOG_ERR;
+	spi->speed = KNC_SPI_SPEED;
+	spi->delay = KNC_SPI_DELAY;
+	spi->mode = KNC_SPI_MODE;
+	spi->bits = KNC_SPI_BITS;
 	
 	if (!knc_spi_open(cgpu->dev_repr, spi))
 		return false;

--- a/driver-littlefury.c
+++ b/driver-littlefury.c
@@ -345,12 +345,13 @@ bool littlefury_thread_init(struct thr_info *thr)
 	for (proc = cgpu; proc; proc = proc->next_proc)
 	{
 		spi = malloc(sizeof(*spi));
-		*spi = (struct spi_port){
-			.txrx = littlefury_txrx,
-			.cgpu = proc,
-			.repr = proc->proc_repr,
-			.logprio = LOG_ERR,
-		};
+		
+		/* Be careful, read spidevc.h comments for warnings */
+		memset(spi, 0, sizeof(*spi));
+		spi->txrx = littlefury_txrx;
+		spi->cgpu = proc;
+		spi->repr = proc->proc_repr;
+		spi->logprio = LOG_ERR;
 		
 		bitfury = malloc(sizeof(*bitfury));
 		*bitfury = (struct bitfury_device){

--- a/driver-nanofury.c
+++ b/driver-nanofury.c
@@ -275,12 +275,13 @@ bool nanofury_init(struct thr_info * const thr)
 		return false;
 	}
 	
-	*port = (struct spi_port){
-		.txrx = nanofury_spi_txrx,
-		.cgpu = cgpu,
-		.repr = cgpu->proc_repr,
-		.logprio = LOG_ERR,
-	};
+	/* Be careful, read spidevc.h comments for warnings */
+	memset(port, 0, sizeof(*port));
+	port->txrx = nanofury_spi_txrx;
+	port->cgpu = cgpu;
+	port->repr = cgpu->proc_repr;
+	port->logprio = LOG_ERR;
+		
 	*bitfury = (struct bitfury_device){
 		.spi = port,
 	};

--- a/spidevc.h
+++ b/spidevc.h
@@ -10,7 +10,8 @@
 /* Initialize SPI using this function */
 void spi_init(void);
 
-/* Do not allocate spi_port on the stack! OS X, at least, has a 512 KB default stack size for secondary threads */
+/* Do not allocate spi_port on the stack! OS X, at least, has a 512 KB default stack size for secondary threads
+   This includes struct assignments which get allocated on the stack before being assigned to */
 struct spi_port {
 	/* TX-RX single frame */
 	bool (*txrx)(struct spi_port *port);


### PR DESCRIPTION
EXC_BAD_ACCESS on Mac OS X
