### PR TITLE
int quirk_reopen (it was bool);

### DIFF
--- a/icarus-common.h
+++ b/icarus-common.h
@@ -83,7 +83,7 @@ struct ICARUS_INFO {
 	int work_division;
 	int fpga_count;
 	uint32_t nonce_mask;
-	bool quirk_reopen;
+	int quirk_reopen;
 	uint8_t user_set;
 	bool continue_search;
 


### PR DESCRIPTION
to avoid:
driver-icarus.c:1057:41: warning: comparison of constant 2 with expression of type 'bool' is always true [-Wtautological-constant-out-of-range-compare]
        if (was_hw_error && info->quirk_reopen != 2) {
                            ~~~~~~~~~~~~~~~~~~ ^  ~
driver-icarus.c:1070:25: warning: comparison of constant 2 with expression of type 'bool' is always false [-Wtautological-constant-out-of-range-compare]
        if (info->quirk_reopen == 2 && !icarus_reopen(icarus, state, &fd))
