### PR TITLE
Bugfix: document the need to package zlib1.dll for Windows

### DIFF
--- a/windows-build.txt
+++ b/windows-build.txt
@@ -261,4 +261,5 @@ C:\MinGW\bin
 	libgpg-error-0.dll
 	libiconv-2.dll
 	libevent-2-0-5.dll
+	zlib1.dll
 


### PR DESCRIPTION
Document the need to package zlib1.dll in the Windows build instructions
