### PR TITLE
Fixed multiple XSS injection vectors

### DIFF
--- a/miner.php
+++ b/miner.php
@@ -181,7 +181,7 @@ $customsummarypages = array('Mobile' => array($mobilepage, $mobilesum),
  'Stats' => array($statspage, $statssum),
  'Pools' => array($poolspage, $poolssum, $poolsext));
 #
-$here = $_SERVER['PHP_SELF'];
+$here = basename(__FILE__);
 #
 global $tablebegin, $tableend, $warnfont, $warnoff, $dfmt;
 #


### PR DESCRIPTION
There are multiple XSS injection vectors caused by `$_SERVER['PHP_SELF']`. 

E.g.: `miner.php/';%7Dalert(1);//`

Fixed it by not relying on `PHP_SELF` at all.
