### PR TITLE
Drillbit support for new protocol revision, miniplane connected boards

### DIFF
--- a/driver-drillbit.c
+++ b/driver-drillbit.c
@@ -95,7 +95,7 @@ err:
 			strcpy(product, "Eight");
 	}
 	else
-	if ((chips % 8 == 0) && !strcmp(product, "Eight"))
+	if ((chips >= 8) && (chips <= 64) && (chips % 8 == 0) && !strcmp(product, "Eight"))
 	{}  // Known device
 	else
 	if (chips == 1 && !strcmp(product, "Thumb"))

--- a/driver-drillbit.c
+++ b/driver-drillbit.c
@@ -95,7 +95,7 @@ err:
 			strcpy(product, "Eight");
 	}
 	else
-	if (chips == 8 && !strcmp(product, "Eight"))
+	if ((chips % 8 == 0) && !strcmp(product, "Eight"))
 	{}  // Known device
 	else
 	if (chips == 1 && !strcmp(product, "Thumb"))
@@ -103,12 +103,11 @@ err:
 	else
 		loglev = LOG_DEBUG;
 	
-	if (protover < DRILLBIT_MIN_VERSION || (loglev == LOG_DEBUG && protover > DRILLBIT_MAX_VERSION))
-		applogr(false, loglev, "%s: %s: Unknown device protocol version %u.",
-		        __func__, devpath, protover);
-	if (protover > DRILLBIT_MAX_VERSION)
-		applogr(false, loglev, "%s: %s: Device firmware uses newer Drillbit protocol %u. We only support up to %u. Find a newer BFGMiner!",
+	if (protover < DRILLBIT_MIN_VERSION || (loglev == LOG_DEBUG && protover > DRILLBIT_MAX_VERSION)) {
+		applogr(false, LOG_ERR, "%s: %s: Device firmware uses newer Drillbit protocol %u. We only support up to %u. Find a newer BFGMiner!",
 		        __func__, devpath, protover, (unsigned)DRILLBIT_MAX_VERSION);
+		return false;
+	}
 	
 	if (protover == 2 && chips == 1)
 		// Production firmware Thumbs don't set any capability bits, so fill in the EXT_CLOCK one

--- a/driver-drillbit.c
+++ b/driver-drillbit.c
@@ -110,11 +110,12 @@ err:
 	else
 		loglev = LOG_DEBUG;
 	
-	if (protover < DRILLBIT_MIN_VERSION || (loglev == LOG_DEBUG && protover > DRILLBIT_MAX_VERSION)) {
-		applogr(false, LOG_ERR, "%s: %s: Device firmware uses newer Drillbit protocol %u. We only support up to %u. Find a newer BFGMiner!",
+	if (protover < DRILLBIT_MIN_VERSION || (loglev == LOG_DEBUG && protover > DRILLBIT_MAX_VERSION))
+		applogr(false, loglev, "%s: %s: Unknown device protocol version %u.",
+		        __func__, devpath, protover);
+	if (protover > DRILLBIT_MAX_VERSION)
+		applogr(false, loglev, "%s: %s: Device firmware uses newer Drillbit protocol %u. We only support up to %u. Find a newer BFGMiner!",
 		        __func__, devpath, protover, (unsigned)DRILLBIT_MAX_VERSION);
-		return false;
-	}
 	
 	if (protover == 2 && chips == 1)
 		// Production firmware Thumbs don't set any capability bits, so fill in the EXT_CLOCK one

--- a/driver-drillbit.c
+++ b/driver-drillbit.c
@@ -31,6 +31,13 @@ enum drillbit_capability {
 	DBC_EXT_CLOCK = 2,
 };
 
+enum drillbit_voltagecfg {
+       DBV_650mV = 0,
+       DBV_750mV = 2,
+       DBV_850mV = 1,
+       DBV_950mV = 3,
+}; // Flags used for pre-V4 configuration format only
+
 struct drillbit_board {
 	unsigned core_voltage;
 	unsigned clock_freq;
@@ -203,13 +210,13 @@ bool drillbit_send_config(struct cgpu_info * const dev)
 	uint8_t buf[7] = {'C'};
 	if(board->protover < 4) {
 		if(board->core_voltage < 750)
-			buf[1] = 0; // 650mV
+			buf[1] = DBV_650mV;
 		else if(board->core_voltage < 850)
-			buf[1] = 1; // 750mV
+			buf[1] = DBV_750mV;
 		else if(board->core_voltage < 950)
-			buf[1] = 2; // 850mV
+			buf[1] = DBV_850mV;
 		else
-			buf[1] = 3; // 950mV
+			buf[1] = DBV_950mV;
 		if(board->clock_freq < 64) // internal clock level, either direct or MHz/5
 			buf[2] = board->clock_freq;
 		else


### PR DESCRIPTION
Hi Luke,

We have a new Drillbit firmware revision in beta release that supports miniplane support (joining multiple boards into a single unit), some details at http://drillbitsystem.com/forum/index.php?topic=307.0

It also brings a new configuration packet format, which is less ASIC-specific (designed to accommodate our forthcoming Avalon-based miners.) Where we previously had fields for "int clock level" and "ext clock freq", we just have a single frequency field now. For Bitfury "internal" clock levels, there's some new logic in the firmware. Frequencies less than 64 are assumed to be clock levels and set directly. Values >=64 are divided by 5 to convert frequency to level, approximately. I've left the Bfgminer settings alone though, the change is fully "behind the scenes" and settings are defined the same as before.

Commit 4acf605 has a bit more detail about that small tweak in the commit message.

Thanks very much for all your hard work with bfgminer. It's really slick. :)

Please let me know if there's anything you'd like me to change.

Angus
