### PR TITLE
Increase stratum proxy difficulty to 16 for SHA256 clients.

### DIFF
--- a/driver-stratum.c
+++ b/driver-stratum.c
@@ -343,7 +343,7 @@ void stratumsrv_mining_subscribe(struct bufferevent *bev, json_t *params, const 
 	if (opt_scrypt)
 		bufferevent_write(bev, "0.000015258556232", 17);
 	else
-		bufferevent_write(bev, "0.9999847412109375", 18);
+		bufferevent_write(bev, "15.999755859375", 15);
 	bufferevent_write(bev, "],\"id\":null,\"method\":\"mining.set_difficulty\"}\n", 46);
 	bufferevent_write(bev, _ssm_notify, _ssm_notify_sz);
 }
@@ -373,7 +373,7 @@ void stratumsrv_mining_submit(struct bufferevent *bev, json_t *params, const cha
 	const char * const nonce = __json_array_string(params, 4);
 	uint8_t xnonce2[work2d_xnonce2sz];
 	uint32_t ntime_n, nonce_n;
-	const float nonce_diff = opt_scrypt ? (1./0x10000) : 1.;
+	const float nonce_diff = opt_scrypt ? (1./0x10000) : 16.;
 	bool is_stale;
 	
 	if (unlikely(!client))
@@ -416,7 +416,7 @@ void stratumsrv_mining_submit(struct bufferevent *bev, json_t *params, const cha
 		timer_set_now(&tv_now);
 		timersub(&tv_now, &conn->tv_hashes_done, &tv_delta);
 		conn->tv_hashes_done = tv_now;
-		const uint64_t hashes = opt_scrypt ? 0x10000 : 0x100000000;
+		const uint64_t hashes = opt_scrypt ? 0x10000 : 0x1000000000;
 		hashes_done(thr, hashes, &tv_delta, NULL);
 	}
 }


### PR DESCRIPTION
Difficulty of 1 is too little for even entry level 100gh hardware now.. And with 'entry level' moving to 500gh over the next few months, this should do for a while.
