### PR TITLE
lowl-vcom: Add support for auto scanning (-S auto) on Mac OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,6 +182,7 @@ case $target in
     use_udevrules=false
     ;;
 	*-*-darwin*)
+		LDFLAGS="$LDFLAGS -framework IOKit -framework CoreFoundation"
 		have_macho=true
     use_udevrules=false
 		;;


### PR DESCRIPTION
Uses I/O Kit to enumerate USB devices
https://developer.apple.com/library/mac/documentation/DeviceDrivers/Conceptual/IOKitFundamentals/Introduction/Introduction.html
http://en.wikipedia.org/wiki/I/O_Kit
