### PR TITLE
gridseed: Bugfix: previous refactor (unpublished) changed logic

### DIFF
--- a/driver-gridseed.c
+++ b/driver-gridseed.c
@@ -213,7 +213,6 @@ int64_t gridseed_scanhash(struct thr_info *thr, struct work *work, int64_t __may
 		{
 			// LTC result
 			gridseed_submit_nonce(thr, buf, work);
-			break;
 		}
 		else
 		{


### PR DESCRIPTION
break; was intended for the now missing switch statement, not the while loop
