### PR TITLE
Bugfix: miner: Check work->blk.nonce to see if work should be abandoned

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -9673,7 +9673,8 @@ out:
 // see minerloop_scanhash comments for more details & usage
 bool abandon_work(struct work *work, struct timeval *wdiff, uint64_t max_hashes)
 {
-	if (wdiff->tv_sec > opt_scantime ||                 // scan-time has elapsed (user specified, default 60s)
+	if (work->blk.nonce == 0xffffffff ||                // known we are scanning a full nonce range
+	    wdiff->tv_sec > opt_scantime ||                 // scan-time has elapsed (user specified, default 60s)
 	    work->blk.nonce >= 0xfffffffe - max_hashes ||   // are there enough nonces left in the work
 	    max_hashes >= 0xfffffffe ||                     // assume we are scanning a full nonce range
 	    stale_work(work, false))                        // work is stale


### PR DESCRIPTION
While this doesn't change behavior outright, it makes the intentions clearer.
Until recent changes the driver scanhash() method would always return the total number of hashes done. This would in turn be (conditionally) assigned to the max_hashes for that device.
Recent changes adding support for per-processor statistics for scanhash-based devices have changed this assumption. In these cases, max_hashes alone may not be a reliable indication of whether the device / driver scans a full nonce range.
