### PR TITLE
Bugfix: zeusminer: Enabling ZeusMiner driver should flag needing lowl-vcom

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -511,6 +511,7 @@ elif test "x$icarus" = "xno"; then
 fi
 if test "x$zeusminer" = "xyes"; then
 	AC_DEFINE([USE_ZEUSMINER], [1], [Defined to 1 if ZeusMiner support is wanted])
+	need_lowl_vcom=yes
 	has_asic=yes
 	$broad_udevrules && have_udevrules=true
 fi


### PR DESCRIPTION
driver-zeusminer.com requires lowl-vcom.h
