### PR TITLE
Bugfix: Fix target calculation from diff < 1.0 in test_hash()

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -9562,7 +9562,7 @@ bool test_hash(const void * const phash, const float diff)
 		// FIXME: > 1 should check more
 		return !hash[7];
 	
-	const uint32_t Htarg = (uint32_t)(0x100000000 * diff) - 1;
+	const uint32_t Htarg = (uint32_t)(1. / diff);
 	const uint32_t tmp_hash7 = le32toh(hash[7]);
 	
 	applog(LOG_DEBUG, "htarget %08lx hash %08lx",


### PR DESCRIPTION
Looks like the target calculation in test_hash() is completely broken for diff < 1. At least it makes no sense to me. With lower difficulty you must have bigger target and vice versa.
The definition of difficulty:
diff = 0x00000000FFFFFF...FF / target,
which means that:
target = 0x00000000FFFFFF...FF / diff,
which approximately equals to:
target = 0x000000010000..00 / diff,

In case of test_hash() function, where we are using only MSW, it gives us (by dropping all the lower words and leaving only the most significant one):
target_MSW= 0x00000001 / diff.

That's why the fix :)
