### PR TITLE
Add BFx2 USB miner instructions to README.ASIC

### DIFF
--- a/README.ASIC
+++ b/README.ASIC
@@ -88,6 +88,20 @@ Then you must run BFGMiner as root, with the proper driver selected.
 For example:
     sudo bfgminer -S bfsb:auto
 
+BFx2 USB
+--------
+You will need to install the WinUSB driver instead of the default FTDI serial
+driver. The easiest way to do this is using Zadig: http://zadig.akeo.ie/
+
+(See https://bitcointalk.org/index.php?topic=524521.msg6194413#msg6194413)
+
+Note that since it's impossible to tell the BFx2 apart from various other
+devices (including BFL/Cairnsmore1 miners and even many non-mining devices!),
+so you must run with the -S bfx:all option (or 'bfx:all' at the M+ menu).
+
+I do not know what this will do with other devices; it may start fires,
+launch nuclear missiles (please don't run BFGMiner on computers with
+missile controls), etc.
 
 BI*FURY
 -------

--- a/README.ASIC
+++ b/README.ASIC
@@ -97,7 +97,7 @@ driver. The easiest way to do this is using Zadig: http://zadig.akeo.ie/
 
 Note that since it's impossible to tell the BFx2 apart from various other
 devices (including BFL/Cairnsmore1 miners and even many non-mining devices!),
-so you must run with the -S bfx:all option (or 'bfx:all' at the M+ menu).
+you must run with the -S bfx:all option (or 'bfx:all' at the M+ menu).
 
 I do not know what this will do with other devices; it may start fires,
 launch nuclear missiles (please don't run BFGMiner on computers with


### PR DESCRIPTION
Using this miner is not obvious since it's necessary to install the WinUSB driver and then pass the -S bfx:all option. I have taken the instructions from the bitcointalk thread (https://bitcointalk.org/index.php?topic=524521.msg6194413) and added them to the README.ASIC file.
