### PR TITLE
Adding additional boolean keywords enable and disable

### DIFF
--- a/util.c
+++ b/util.c
@@ -2194,6 +2194,7 @@ struct bfg_strtobool_keyword {
 bool bfg_strtobool(const char * const s, char ** const endptr, __maybe_unused const int opts)
 {
 	struct bfg_strtobool_keyword keywords[] = {
+		{false, "disable"},
 		{false, "false"},
 		{false, "never"},
 		{false, "none"},
@@ -2201,6 +2202,7 @@ bool bfg_strtobool(const char * const s, char ** const endptr, __maybe_unused co
 		{false, "no"},
 		{false, "0"},
 		
+		{true , "enable"},
 		{true , "always"},
 		{true , "true"},
 		{true , "yes"},


### PR DESCRIPTION
Adding yet another pair of English words that are commonly used
as Boolean directives.
