### PR TITLE
Shut up needless compiler warnings

### DIFF
--- a/driver-bifury.c
+++ b/driver-bifury.c
@@ -419,7 +419,8 @@ void bifury_handle_cmd(struct cgpu_info * const dev, const char * const cmd)
 	{
 		// job <jobid> <timestamp> <chip>
 		const uint32_t jobid = strtoll(&cmd[4], &p, 0x10);
-		strtoll(&p[1], &p, 0x10);
+		if (strtoll(&p[1], &p, 0x10))
+			; // Shut up compiler warning
 		const int chip = atoi(&p[1]);
 		const struct cgpu_info * const proc = device_proc_by_id(dev, chip);
 		

--- a/util.c
+++ b/util.c
@@ -2220,7 +2220,8 @@ bool bfg_strtobool(const char * const s, char ** const endptr, __maybe_unused co
 	}
 	
 	char *lend;
-	strtol(s, &lend, 0);
+	if (strtol(s, &lend, 0))
+		; // Shut up compiler warning
 	if (lend > s)
 	{
 		if (endptr)


### PR DESCRIPTION
Suppressing warnings about unused results.
Merely casting the results to void isn't good enough to keep fooling
newest compiler versions, so instead using an empty if statement.
