### PR TITLE
Put units on all numbers, not one combined unit for all numbers.

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -3925,19 +3925,11 @@ char *_multi_format_unit(char **buflist, size_t *bufszlist, bool floatprec, cons
 		delimsz = strlen(delim);
 	
 	for (i = 0; i < count; ++i)
-		if (numbers[i] != 0)
-		{
-			pick_unit(numbers[i], &unit);
-			allzero = false;
-		}
-	
-	if (allzero)
-		unit = _unitbase;
-	
-	--count;
-	for (i = 0; i < count; ++i)
 	{
-		format_unit2(buf, bufsz, floatprec, NULL, H2B_NOUNIT, numbers[i], unit);
+		unit = 0;
+		pick_unit(numbers[i], &unit);
+
+		format_unit2(buf, bufsz, floatprec, measurement, fmt, numbers[i], unit);
 		if (isarray)
 		{
 			buf = buflist[i + 1];
@@ -3954,9 +3946,6 @@ char *_multi_format_unit(char **buflist, size_t *bufszlist, bool floatprec, cons
 			bufsz -= delimsz;
 		}
 	}
-	
-	// Last entry has the unit
-	format_unit2(buf, bufsz, floatprec, measurement, fmt, numbers[count], unit);
 	
 	return buflist[0];
 }


### PR DESCRIPTION
Added units to every formatted number to allow for different units
on largely different numbers.  This prevents one out-of-whack number
from setting the unit so that the other numbers become hidden in
rounding errors.  It does take one more character per number, though.

https://github.com/luke-jr/bfgminer/issues/589
