### PR TITLE
Fixes regarding wrong statistics display

### DIFF
--- a/README
+++ b/README
@@ -308,6 +308,7 @@ Options for both config file and command line:
 --real-quiet        Disable all output
 --request-diff <arg> Request a specific difficulty from pools (default: 1.0)
 --retries <arg>     Number of times to retry failed submissions before giving up (-1 means never) (default: -1)
+--retroactive-diff  Adjust difficulty of the shares retroactively (broken pools support). Pool option.
 --rotate <arg>      Change multipool strategy from failover to regularly rotate at N minutes (default: 0)
 --round-robin       Change multipool strategy from failover to round robin on failure
 --scan|-S <arg>     Configure how to scan for mining devices

--- a/api.c
+++ b/api.c
@@ -1486,7 +1486,7 @@ void devstatus_an(struct io_data *io_data, struct cgpu_info *cgpu, bool isjson, 
 		if (proc->deven != DEV_DISABLED)
 			enabled = true;
 		total_mhashes += proc->total_mhashes;
-		rolling += proc->rolling;
+		rolling += proc->drv->get_proc_rolling_hashrate ? proc->drv->get_proc_rolling_hashrate(proc) : proc->rolling;
 		utility += proc->utility;
 		accepted += proc->accepted;
 		rejected += proc->rejected;
@@ -1512,9 +1512,6 @@ void devstatus_an(struct io_data *io_data, struct cgpu_info *cgpu, bool isjson, 
 		if (per_proc)
 			break;
 	}
-
-	if ((!per_proc) && (cgpu->device == cgpu) && (cgpu->drv->get_master_rolling_hashrate))
-		rolling = cgpu->drv->get_master_rolling_hashrate(cgpu);
 
 	root = api_add_int(root, "PGA", &n, true);
 	root = api_add_device_identifier(root, cgpu);

--- a/driver-titan.c
+++ b/driver-titan.c
@@ -129,17 +129,17 @@ static void knc_titan_zero_stats(struct cgpu_info *cgpu)
 	}
 }
 
-static double knc_titan_get_device_rolling_hashrate(struct cgpu_info *device)
+static double knc_titan_get_die_rolling_hashrate(struct cgpu_info *device)
 {
-	int asic = ((struct knc_titan_die *)device->thr[0]->cgpu_data)->asicno;
+	struct knc_titan_die *die = device->thr[0]->cgpu_data;
+	int asicno = die->asicno;
+	int dieno = die->dieno;
 	struct knc_titan_info *knc = device->device_data;
 	double hashrate = 0.0;
-	int dieno, i;
+	int i;
 
-	for (dieno = 0; dieno < KNC_TITAN_DIES_PER_ASIC; ++dieno) {
-		for (i = 0; i < HASHES_BUF_ENTRIES; ++i) {
-			hashrate += (double)knc->dies[asic][dieno].hashes_buf[i] / 1.0e6;
-		}
+	for (i = 0; i < HASHES_BUF_ENTRIES; ++i) {
+		hashrate += (double)knc->dies[asicno][dieno].hashes_buf[i] / 1.0e6;
 	}
 
 	return hashrate / ((double)(HASHES_BUF_ENTRIES * HASHES_BUF_ONE_ENTRY_TIME));
@@ -947,7 +947,7 @@ struct device_drv knc_titan_drv =
 	.prepare_work = knc_titan_prepare_work,
 
 	/* additional statistics */
-	.get_master_rolling_hashrate = knc_titan_get_device_rolling_hashrate,
+	.get_proc_rolling_hashrate = knc_titan_get_die_rolling_hashrate,
 	.zero_stats = knc_titan_zero_stats,
 
 	/* TUI support - e.g. setting clock via UI */

--- a/miner.c
+++ b/miner.c
@@ -395,13 +395,9 @@ static int include_count;
 #define JSON_LOAD_ERROR_LEN strlen(JSON_LOAD_ERROR)
 #define JSON_MAX_DEPTH 10
 #define JSON_MAX_DEPTH_ERR "Too many levels of JSON includes (limit 10) or a loop"
-<<<<<<<
+#define JSON_WEB_ERROR "WEB config err"
 
 char *cmd_idle, *cmd_sick, *cmd_dead;
-|||||||
-=======
-#define JSON_WEB_ERROR "WEB config err"
->>>>>>>
 
 #if defined(unix) || defined(__APPLE__)
 	static char *opt_stderr_cmd = NULL;
@@ -2908,6 +2904,7 @@ static char *load_web_config(const char *arg)
 {
 	json_t *val;
 	CURL *curl;
+	struct bfg_loaded_configfile *cfginfo;
 
 	curl = curl_easy_init();
 	if (unlikely(!curl))
@@ -2920,12 +2917,15 @@ static char *load_web_config(const char *arg)
 	if (!val || !json_is_object(val))
 		return JSON_WEB_ERROR;
 
-	if (!cnfbuf)
-		cnfbuf = strdup(arg);
+	cfginfo = malloc(sizeof(*cfginfo));
+	*cfginfo = (struct bfg_loaded_configfile){
+		.filename = strdup(arg),
+	};
+	LL_APPEND(bfg_loaded_configfiles, cfginfo);
 
 	config_loaded = true;
 
-	return parse_config(val, true);
+	return parse_config(val, true, &cfginfo->fileconf_load);
 }
 
 static char *load_config(const char *arg, void __maybe_unused *unused)
@@ -2934,23 +2934,11 @@ static char *load_config(const char *arg, void __maybe_unused *unused)
 	json_t *config;
 	char *json_error;
 	size_t siz;
-<<<<<<<
 	struct bfg_loaded_configfile *cfginfo;
-|||||||
 
-	if (!cnfbuf)
-		cnfbuf = strdup(arg);
-=======
-
-#ifdef HAVE_LIBCURL
 	if (strncasecmp(arg, conf_web1, sizeof(conf_web1)-1) == 0 ||
 	    strncasecmp(arg, conf_web2, sizeof(conf_web2)-1) == 0)
 		return load_web_config(arg);
-#endif
-
-	if (!cnfbuf)
-		cnfbuf = strdup(arg);
->>>>>>>
 
 	cfginfo = malloc(sizeof(*cfginfo));
 	*cfginfo = (struct bfg_loaded_configfile){

--- a/miner.c
+++ b/miner.c
@@ -1941,6 +1941,19 @@ static char *set_pool_force_rollntime(const char *arg)
 	return NULL;
 }
 
+static char *set_pool_retroactive_diff(const char *arg)
+{
+	struct pool *pool;
+
+	if (!total_pools)
+		return "Usage of --retroactive-diff before pools are defined does not make sense";
+
+	pool = pools[total_pools - 1];
+	opt_set_bool(&pool->pool_diff_effective_retroactively);
+
+	return NULL;
+}
+
 static char *enable_debug(bool *flag)
 {
 	*flag = true;
@@ -2795,6 +2808,9 @@ static struct opt_table opt_config_table[] = {
 	OPT_WITHOUT_ARG("--worktime",
 			opt_set_bool, &opt_worktime,
 			"Display extra work time debug information"),
+	OPT_WITHOUT_ARG("--retroactive-diff",
+			set_pool_retroactive_diff, NULL,
+			"Adjust difficulty of the shares retroactively (broken pools support)"),
 	OPT_WITH_ARG("--pools",
 			opt_set_bool, NULL, NULL, opt_hidden),
 	OPT_ENDTABLE
@@ -7824,6 +7840,8 @@ void write_config(FILE *fcfg)
 		fprintf(fcfg, "\n\t\t\"pool-priority\" : \"%d\"", pool->prio);
 		if (pool->force_rollntime)
 			fprintf(fcfg, ",\n\t\t\"force-rollntime\" : %d", pool->force_rollntime);
+		if (pool->pool_diff_effective_retroactively)
+			fprintf(fcfg, ",\n\t\t\"retroactive-diff\" : true");
 		fprintf(fcfg, "\n\t}");
 	}
 	fputs("\n]\n", fcfg);
@@ -10536,15 +10554,19 @@ enum test_nonce2_result _test_nonce2(struct work *work, uint32_t nonce, bool che
 		struct pool * const pool = work->pool;
 		if (pool->stratum_active)
 		{
-			// Some stratum pools are buggy and expect difficulty changes to be immediate retroactively, so if the target has changed, check and submit just in case
-			if (memcmp(pool->next_target, work->target, sizeof(work->target)))
+			if (pool->pool_diff_effective_retroactively)
 			{
-				applog(LOG_DEBUG, "Stratum pool %u target has changed since work job issued, checking that too",
-				       pool->pool_no);
-				if (hash_target_check_v(work->hash, pool->next_target)) {
-					high_hash = false;
-					memcpy(work->target, pool->next_target, sizeof(work->target));
-					calc_diff(work, 0);
+				// Some stratum pools are buggy and expect difficulty changes to be immediate retroactively, so if the target has changed, check and submit just in case
+				if (memcmp(pool->next_target, work->target, sizeof(work->target)))
+				{
+					applog(LOG_DEBUG, "Stratum pool %u target has changed since work job issued, checking that too as requested by user",
+					       pool->pool_no);
+					if (hash_target_check_v(work->hash, pool->next_target))
+					{
+						high_hash = false;
+						memcpy(work->target, pool->next_target, sizeof(work->target));
+						calc_diff(work, 0);
+					}
 				}
 			}
 		}

--- a/miner.c
+++ b/miner.c
@@ -10505,8 +10505,11 @@ enum test_nonce2_result _test_nonce2(struct work *work, uint32_t nonce, bool che
 			{
 				applog(LOG_DEBUG, "Stratum pool %u target has changed since work job issued, checking that too",
 				       pool->pool_no);
-				if (hash_target_check_v(work->hash, pool->next_target))
+				if (hash_target_check_v(work->hash, pool->next_target)) {
 					high_hash = false;
+					memcpy(work->target, pool->next_target, sizeof(work->target));
+					calc_diff(work, 0);
+				}
 			}
 		}
 		if (high_hash)

--- a/miner.c
+++ b/miner.c
@@ -2,7 +2,7 @@
  * Copyright 2011-2014 Con Kolivas
  * Copyright 2011-2014 Luke Dashjr
  * Copyright 2014 Nate Woolls
- * Copyright 2012-2013 Andrew Smith
+ * Copyright 2012-2014 Andrew Smith
  * Copyright 2010 Jeff Garzik
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -395,8 +395,13 @@ static int include_count;
 #define JSON_LOAD_ERROR_LEN strlen(JSON_LOAD_ERROR)
 #define JSON_MAX_DEPTH 10
 #define JSON_MAX_DEPTH_ERR "Too many levels of JSON includes (limit 10) or a loop"
+<<<<<<<
 
 char *cmd_idle, *cmd_sick, *cmd_dead;
+|||||||
+=======
+#define JSON_WEB_ERROR "WEB config err"
+>>>>>>>
 
 #if defined(unix) || defined(__APPLE__)
 	static char *opt_stderr_cmd = NULL;
@@ -2896,13 +2901,56 @@ static char *parse_config(json_t *config, bool fileconf, int * const fileconf_lo
 
 struct bfg_loaded_configfile *bfg_loaded_configfiles;
 
+char conf_web1[] = "http://";
+char conf_web2[] = "https://";
+
+static char *load_web_config(const char *arg)
+{
+	json_t *val;
+	CURL *curl;
+
+	curl = curl_easy_init();
+	if (unlikely(!curl))
+		quithere(1, "CURL initialisation failed");
+
+	val = json_web_config(curl, arg);
+
+	curl_easy_cleanup(curl);
+
+	if (!val || !json_is_object(val))
+		return JSON_WEB_ERROR;
+
+	if (!cnfbuf)
+		cnfbuf = strdup(arg);
+
+	config_loaded = true;
+
+	return parse_config(val, true);
+}
+
 static char *load_config(const char *arg, void __maybe_unused *unused)
 {
 	json_error_t err;
 	json_t *config;
 	char *json_error;
 	size_t siz;
+<<<<<<<
 	struct bfg_loaded_configfile *cfginfo;
+|||||||
+
+	if (!cnfbuf)
+		cnfbuf = strdup(arg);
+=======
+
+#ifdef HAVE_LIBCURL
+	if (strncasecmp(arg, conf_web1, sizeof(conf_web1)-1) == 0 ||
+	    strncasecmp(arg, conf_web2, sizeof(conf_web2)-1) == 0)
+		return load_web_config(arg);
+#endif
+
+	if (!cnfbuf)
+		cnfbuf = strdup(arg);
+>>>>>>>
 
 	cfginfo = malloc(sizeof(*cfginfo));
 	*cfginfo = (struct bfg_loaded_configfile){

--- a/miner.c
+++ b/miner.c
@@ -4159,7 +4159,7 @@ void get_statline3(char *buf, size_t bufsz, struct cgpu_info *cgpu, bool for_cur
 			slave->utility = slave->accepted / dev_runtime * 60;
 			slave->utility_diff1 = slave->diff_accepted / dev_runtime * 60;
 			
-			rolling += slave->rolling;
+			rolling += drv->get_proc_rolling_hashrate ? drv->get_proc_rolling_hashrate(slave) : slave->rolling;
 			mhashes += slave->total_mhashes;
 			if (opt_weighed_stats)
 			{
@@ -4183,9 +4183,6 @@ void get_statline3(char *buf, size_t bufsz, struct cgpu_info *cgpu, bool for_cur
 				break;
 		}
 	}
-
-	if ((cgpu->device == cgpu) && (drv->get_master_rolling_hashrate))
-		rolling = drv->get_master_rolling_hashrate(cgpu);
 
 	double wtotal = (waccepted + wnotaccepted);
 	

--- a/miner.h
+++ b/miner.h
@@ -337,7 +337,7 @@ struct device_drv {
 	void (*proc_tui_wlogprint_choices)(struct cgpu_info *);
 	const char *(*proc_tui_handle_choice)(struct cgpu_info *, int input);
 	void (*zero_stats)(struct cgpu_info *);
-	double (*get_master_rolling_hashrate)(struct cgpu_info *);
+	double (*get_proc_rolling_hashrate)(struct cgpu_info *);
 
 	// Thread-specific functions
 	bool (*thread_prepare)(struct thr_info *);

--- a/miner.h
+++ b/miner.h
@@ -1361,6 +1361,7 @@ struct pool {
 	char work_restart_timestamp[11];
 	uint32_t	block_id;
 	struct mining_goal_info *goal;
+	bool pool_diff_effective_retroactively;
 
 	enum pool_protocol proto;
 

--- a/miner.h
+++ b/miner.h
@@ -1016,6 +1016,13 @@ extern int swork_id;
 extern pthread_rwlock_t netacc_lock;
 
 extern const uint32_t sha256_init_state[];
+<<<<<<< HEAD
+||||||| parent of c7d6886... allow url based config files
+#ifdef HAVE_LIBCURL
+=======
+#ifdef HAVE_LIBCURL
+extern json_t *json_web_config(CURL *curl, const char *url);
+>>>>>>> c7d6886... allow url based config files
 extern json_t *json_rpc_call(CURL *curl, const char *url, const char *userpass,
 			     const char *rpc_req, bool, bool, int *,
 			     struct pool *pool, bool);

--- a/miner.h
+++ b/miner.h
@@ -1016,13 +1016,7 @@ extern int swork_id;
 extern pthread_rwlock_t netacc_lock;
 
 extern const uint32_t sha256_init_state[];
-<<<<<<< HEAD
-||||||| parent of c7d6886... allow url based config files
-#ifdef HAVE_LIBCURL
-=======
-#ifdef HAVE_LIBCURL
 extern json_t *json_web_config(CURL *curl, const char *url);
->>>>>>> c7d6886... allow url based config files
 extern json_t *json_rpc_call(CURL *curl, const char *url, const char *userpass,
 			     const char *rpc_req, bool, bool, int *,
 			     struct pool *pool, bool);

--- a/util.c
+++ b/util.c
@@ -450,11 +450,6 @@ static int curl_debug_cb(__maybe_unused CURL *handle, curl_infotype type,
 	return 0;
 }
 
-<<<<<<< HEAD
-void json_rpc_call_async(CURL *curl, const char *url,
-||||||| parent of c7d6886... allow url based config files
-json_t *json_rpc_call(CURL *curl, const char *url,
-=======
 json_t *json_web_config(CURL *curl, const char *url)
 {
 	struct data_buffer all_data = {NULL, 0};
@@ -468,6 +463,9 @@ json_t *json_web_config(CURL *curl, const char *url)
 
 	/* it is assumed that 'curl' is freshly [re]initialized at this pt */
 
+	curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1);
+	curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1);
+	
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
 
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
@@ -505,12 +503,10 @@ json_t *json_web_config(CURL *curl, const char *url)
 c_out:
 	databuf_free(&all_data);
 	curl_easy_reset(curl);
-	curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1);
 	return val;
 }
 
-json_t *json_rpc_call(CURL *curl, const char *url,
->>>>>>> c7d6886... allow url based config files
+void json_rpc_call_async(CURL *curl, const char *url,
 		      const char *userpass, const char *rpc_req,
 		      bool longpoll,
 		      struct pool *pool, bool share,

--- a/util.c
+++ b/util.c
@@ -450,7 +450,67 @@ static int curl_debug_cb(__maybe_unused CURL *handle, curl_infotype type,
 	return 0;
 }
 
+<<<<<<< HEAD
 void json_rpc_call_async(CURL *curl, const char *url,
+||||||| parent of c7d6886... allow url based config files
+json_t *json_rpc_call(CURL *curl, const char *url,
+=======
+json_t *json_web_config(CURL *curl, const char *url)
+{
+	struct data_buffer all_data = {NULL, 0};
+	char curl_err_str[CURL_ERROR_SIZE];
+	json_error_t err;
+	long timeout = 60;
+	json_t *val;
+	int rc;
+
+	memset(&err, 0, sizeof(err));
+
+	/* it is assumed that 'curl' is freshly [re]initialized at this pt */
+
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_ENCODING, "");
+	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
+
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, all_data_cb);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &all_data);
+	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_err_str);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+	curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_TRY);
+
+	val = NULL;
+	rc = curl_easy_perform(curl);
+	if (rc) {
+		applog(LOG_ERR, "HTTP config request of '%s' failed: %s",
+				url, curl_err_str);
+		goto c_out;
+	}
+
+	if (!all_data.buf) {
+		applog(LOG_ERR, "Empty config data received from '%s'",
+				url);
+		goto c_out;
+	}
+
+	val = JSON_LOADS(all_data.buf, &err);
+	if (!val) {
+		applog(LOG_ERR, "JSON config decode of '%s' failed(%d): %s",
+				url, err.line, err.text);
+		goto c_out;
+	}
+
+c_out:
+	databuf_free(&all_data);
+	curl_easy_reset(curl);
+	curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1);
+	return val;
+}
+
+json_t *json_rpc_call(CURL *curl, const char *url,
+>>>>>>> c7d6886... allow url based config files
 		      const char *userpass, const char *rpc_req,
 		      bool longpoll,
 		      struct pool *pool, bool share,


### PR DESCRIPTION
Two fixes of wrongly displayed statistics.
1) First commit fixes wrong numbers in "detail level:processors" view (for Titans, which are the only devices using get_master_rolling_hashrate). First processor shows wrong rolling hashrate in that view;
2) Second commit fixes general problem of using incorrect difficulty when calculating diff_stale.
