### PR TITLE
Fix to Sub Modules | Ensure Pool is sending block contents (acttx) before evaluating as fishy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "libblkmaker"]
-	path = libblkmaker
-	url = git://github.com/bitcoin/libblkmaker.git
+    path = libblkmaker
+    url = https://gitorious.org/bitcoin/libblkmaker.git
 [submodule "ccan"]
-	path = ccan-upstream
-	url = git://git.ozlabs.org/~ccan/ccan
+    path = ccan-upstream
+    url = git://git.ozlabs.org/~ccan/ccan
 [submodule "libbase58"]
-	path = libbase58
-	url = git://github.com/luke-jr/libbase58.git
+    path = libbase58
+    url = https://github.com/luke-jr/libbase58.git
 [submodule "knc-asic"]
-	path = knc-asic
-	url = git://github.com/KnCMiner/knc-asic
+    path = knc-asic
+    url = https://github.com/KnCMiner/knc-asic.git

--- a/miner.c
+++ b/miner.c
@@ -9194,7 +9194,7 @@ bool parse_stratum_response(struct pool *pool, char *s)
 				unsigned mintx = maxtx >> 1;
 				--maxtx;
 				unsigned acttx = (unsigned)json_array_size(res_val);
-				if (acttx < mintx || acttx > maxtx) {
+				if (acttx && (acttx < mintx || acttx > maxtx)) {
 					applog(LOG_WARNING, "Pool %u is sending mismatched block contents to us (%u is not %u-%u)",
 					       pool->pool_no, acttx, mintx, maxtx);
 					goto fishy;


### PR DESCRIPTION
## Fix to Sub Modules

git:// protocol is typically used when explicit read/write/admin access has been granted for the user.  https:// protocol should be used for read-only use, such as for modules and dependencies.

Some users have set up configurations (ie: ssh) to connect to some hubs (ie: GitHub, BitBucket) with special keys.  This can cause complications when these users have not been granted read/write/admin access through git.
## Ensure Pool is sending block contents (acttx) before evaluating as fishy

Checking for server response before declaring mismatch.
