### PR TITLE
Fix to enable building into directory out of source tree

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,8 +92,8 @@ TEST_EXTENSIONS = .sh
 
 .PHONY: update-version
 update-version:
-	./gen-version.sh >version.h.new
-	cmp version.h version.h.new && rm version.h.new || mv version.h.new version.h
+	$(top_srcdir)/gen-version.sh >version.h.new
+	cmp $(top_srcdir)/version.h version.h.new && rm version.h.new || mv version.h.new $(top_srcdir)/version.h
 version.h: update-version
 bfgminer_SOURCES += version.c version.h
 BUILT_SOURCES = version.h

--- a/m4/bundled_lib.m4
+++ b/m4/bundled_lib.m4
@@ -50,7 +50,7 @@ AC_DEFUN([BFG_BUNDLED_LIB_VARS],[
 	BFG_CHECK_LD_ORIGIN
 	_AC_SRCDIRS(["$ac_dir"])
 	$1_CFLAGS='-I'"${ac_abs_top_srcdir}"'/$2'
-	$1_LIBS='-L'"${ac_abs_top_srcdir}"'/$2/.libs -Wl,-rpath,\$$ORIGIN/$2/.libs'"$origin_LDFLAGS"' m4_foreach_w([mylib],[$3],[ -l[]mylib])'
+	$1_LIBS='-L'"${ac_abs_top_builddir}"'/$2/.libs -Wl,-rpath,\$$ORIGIN/$2/.libs'"$origin_LDFLAGS"' m4_foreach_w([mylib],[$3],[ -l[]mylib])'
 	$1_SUBDIRS=$2
 	$1_EXTRADEPS=$1_directory
 	BUNDLED_LIB_RULES="$BUNDLED_LIB_RULES


### PR DESCRIPTION
This make it possible to "`../configure && make`" into a separate subdirectory.
(That's useful when building for multiple arches, each into its own subdirectory. Or simply to keep the source tree (relatively) clean)
