### PR TITLE
fix warning: checking address of array

### DIFF
--- a/adl.c
+++ b/adl.c
@@ -385,9 +385,12 @@ void init_adl(int nDevs)
 		}
 
 		applog(LOG_INFO, "GPU %d %s hardware monitoring enabled", gpu, lpInfo[i].strAdapterName);
-		if (gpus[gpu].name)
+		if (gpus[gpu].name) {
 			free((void*)gpus[gpu].name);
-		gpus[gpu].name = trimmed_strdup(lpInfo[i].strAdapterName);
+			gpus[gpu].name = NULL;
+		}
+		if (lpInfo[i].strAdapterName[0])
+			gpus[gpu].name = trimmed_strdup(lpInfo[i].strAdapterName);
 		data->has_adl = true;
 		/* Flag adl as active if any card is successfully activated */
 		adl_active = true;

--- a/adl.c
+++ b/adl.c
@@ -387,8 +387,7 @@ void init_adl(int nDevs)
 		applog(LOG_INFO, "GPU %d %s hardware monitoring enabled", gpu, lpInfo[i].strAdapterName);
 		if (gpus[gpu].name)
 			free((void*)gpus[gpu].name);
-		if (lpInfo[i].strAdapterName)
-			gpus[gpu].name = trimmed_strdup(lpInfo[i].strAdapterName);
+		gpus[gpu].name = trimmed_strdup(lpInfo[i].strAdapterName);
 		data->has_adl = true;
 		/* Flag adl as active if any card is successfully activated */
 		adl_active = true;


### PR DESCRIPTION
to avoid:
```
  CC       bfgminer-adl.o
adl.c:390:17: warning: address of array 'lpInfo[i].strAdapterName' will always evaluate to 'true' [-Wpointer-bool-conversion]
                if (lpInfo[i].strAdapterName)
                ~~  ~~~~~~~~~~^~~~~~~~~~~~~~
1 warning generated.
```