### PR TITLE
Fix for mingw build

### DIFF
--- a/winhacks.h
+++ b/winhacks.h
@@ -13,4 +13,8 @@
 #	undef MOUSE_MOVED
 #endif
 
+#ifdef interface
+#undef interface
+#endif
+
 #endif


### PR DESCRIPTION
I went with a more minimal fix than the one discussed in #753, undefining `interface`  rather than changing any variable names.