### PR TITLE
docs: fix simple typo, mutliple -> multiple

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -10131,7 +10131,7 @@ retry:
 	/* Signal the getwork scheduler to look for more work */
 	pthread_cond_signal(&gws_cond);
 
-	/* Signal hash_pop again in case there are mutliple hash_pop waiters */
+	/* Signal hash_pop again in case there are multiple hash_pop waiters */
 	pthread_cond_signal(&getq->cond);
 	mutex_unlock(stgd_lock);
 	work->pool->last_work_time = time(NULL);


### PR DESCRIPTION
There is a small typo in miner.c.

Should read `multiple` rather than `mutliple`.

