### PR TITLE
submodules: Changing git to https protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "libblkmaker"]
 	path = libblkmaker
-	url = git://github.com/bitcoin/libblkmaker.git
+	url = https://github.com/bitcoin/libblkmaker.git
 [submodule "ccan"]
 	path = ccan-upstream
-	url = git://git.ozlabs.org/~ccan/ccan
+	url = https://git.ozlabs.org/~ccan/ccan
 [submodule "libbase58"]
 	path = libbase58
-	url = git://github.com/luke-jr/libbase58.git
+	url = https://github.com/luke-jr/libbase58.git
 [submodule "knc-asic"]
 	path = knc-asic
-	url = git://github.com/KnCMiner/knc-asic
+	url = https://github.com/KnCMiner/knc-asic


### PR DESCRIPTION
GitHub has discontinued support for the git protocol:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Changing git:// to https:// accordingly.
Tested, and it now works, instead of timing out.
