### PR TITLE
Adding the new SI prefixes for bigger units

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -3878,7 +3878,7 @@ utility_to_hashrate(double utility)
 	return utility * 0x4444444;
 }
 
-static const char*_unitchar = "pn\xb5m kMGTPEZY?";
+static const char*_unitchar = "pn\xb5m kMGTPEZYRQ?";
 static const int _unitbase = 4;
 
 static


### PR DESCRIPTION
Finally, they have added more prefixes beyond yotta:
https://www.bipm.org/en/cgpm-2022/resolution-3

Adding RH and QH for ronnahashes and quettahashes respectively.
Who knows, we might get there someday....
